### PR TITLE
feat: add automatic entrypoint detection with 'accept: text/html' header

### DIFF
--- a/.changeset/angry-walls-shave.md
+++ b/.changeset/angry-walls-shave.md
@@ -1,0 +1,5 @@
+---
+"@workleap/netlify-skew-protection": patch
+---
+
+Add automatic entrypoint detection using "Accept: text/html" request header.

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -8,6 +8,14 @@ export const CookieName = "nf_sp";
 
 export interface CreateSkewProtectionFunctionOptions {
     /**
+     * Name of the files that should be considered entrypoints, and that should
+     * set a skew protection cookie.
+     *
+     * If you're building a SPA, you can leave this empty since we use the
+     * `Accept: text/html` header to determine if the request is a page load.
+     */
+    entrypoints?: string[];
+    /**
      * We don't want users to be able to access very old versions of the site, so
      * the cookie is signed with HMAC to prevent tampering.
      * The secret must be configured as an environment variable of the Netlify site
@@ -148,8 +156,9 @@ function rerouteRequest(target: URL, originalRequest: Request) {
     return fetch(target, originalRequest);
 }
 
-export function createSkewProtectionFunction(entrypoints: string[], options: CreateSkewProtectionFunctionOptions = {}) {
+export function createSkewProtectionFunction(options: CreateSkewProtectionFunctionOptions = {}) {
     const {
+        entrypoints = [],
         secretEnvironmentVariableName = SecretEnvironmentVariable,
         basicAuthPasswordEnvironmentVariableName = BasicAuthPasswordEnvironmentVariableName,
         cookieName = CookieName,

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -182,9 +182,14 @@ export function createSkewProtectionFunction(entrypoints: string[], options: Cre
 
             const url = new URL(request.url);
 
+            // For SPAs, since any URL pathname could be an entrypoint, we
+            // instead check if the browser is requesting HTML content. If yes,
+            // we can confidently assume that this is a page load request.
+            const isPageLoadRequest = request.headers.get("Accept")?.toLowerCase().includes("text/html");
+
             logDebug("The request URL path name is:", url.pathname);
 
-            if (entrypoints.includes(url.pathname)) {
+            if (entrypoints.includes(url.pathname) || isPageLoadRequest) {
                 logDebug(`One of the provided entrypoint match the request URL path name, writing a cookie with the ${context.deploy.id} deployment id and exiting.`);
 
                 context.cookies.set({

--- a/lib/tests/createSkewProtectionFunction.test.ts
+++ b/lib/tests/createSkewProtectionFunction.test.ts
@@ -36,7 +36,8 @@ test("when an entrypoint is requested, skew protection cookie is set", async ({ 
     };
 
     // Create the skew protection function.
-    const fct = createSkewProtectionFunction(["/manifest.json"], {
+    const fct = createSkewProtectionFunction({
+        entrypoints: ["/manifest.json"],
         secretEnvironmentVariableName: SecretKey
     });
 
@@ -79,7 +80,8 @@ test("when the resource is requested with a cookie already set, load the file fr
     };
 
     // Create the skew protection function.
-    const fct = createSkewProtectionFunction(["/manifest.json"], {
+    const fct = createSkewProtectionFunction({
+        entrypoints: ["/manifest.json"],
         secretEnvironmentVariableName: SecretKey
     });
 

--- a/sample/netlify/edge-functions/skew-protection.ts
+++ b/sample/netlify/edge-functions/skew-protection.ts
@@ -1,7 +1,5 @@
 import { config, createSkewProtectionFunction } from "@workleap/netlify-skew-protection";
 
-const fct = createSkewProtectionFunction(["/", "/index.html"], {
-    debug: true
-});
+const fct = createSkewProtectionFunction({ debug: true });
 
 export { config, fct as default };


### PR DESCRIPTION
For SPAs, since any URL pathname could be an entrypoint, we instead check if the browser is requesting HTML content. If yes, we can confidently assume that this is a page load request and set the skew-protection cookie.